### PR TITLE
Fix: Save filtered results in filter_image_table

### DIFF
--- a/PosterAgent/gen_outline_layout.py
+++ b/PosterAgent/gen_outline_layout.py
@@ -301,8 +301,8 @@ def filter_image_table(args, filter_config):
     response_json = get_json_from_response(response.msgs[0].content)
     table_information = response_json['table_information']
     image_information = response_json['image_information']
-    json.dump(images, open(f'<{args.model_name_t}_{args.model_name_v}>_images_and_tables/{args.poster_name}_images_filtered.json', 'w'), indent=4)
-    json.dump(tables, open(f'<{args.model_name_t}_{args.model_name_v}>_images_and_tables/{args.poster_name}_tables_filtered.json', 'w'), indent=4)
+    json.dump(image_information, open(f'<{args.model_name_t}_{args.model_name_v}>_images_and_tables/{args.poster_name}_images_filtered.json', 'w'), indent=4)
+    json.dump(table_information, open(f'<{args.model_name_t}_{args.model_name_v}>_images_and_tables/{args.poster_name}_tables_filtered.json', 'w'), indent=4)
 
     return input_token, output_token
 


### PR DESCRIPTION
This PR fixes a bug in filter_image_table where the original, unprocessed variables were being saved instead of the filtered results.

**Fix:**

- Modifies json.dump to use image_information and table_information variables.

**Related Issue:** Closes #41