### PR TITLE
Bump transformers to >=4.51.0 (CVE-2025-3263)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -517,7 +517,7 @@ tomlkit==0.13.2
 tornado==6.4.2
 tqdm==4.67.1
 traitlets==5.14.3
-transformers==4.48.0
+transformers>=4.51.0
 tree-sitter==0.23.2
 tree-sitter-python==0.23.6
 trio==0.28.0


### PR DESCRIPTION
Follows up on the issue: `requirements.txt` pinned `transformers==4.48.0`, which is in the affected range of CVE-2025-3263 (ReDoS in `get_configuration_file`, fixed in 4.51.0).

This is the one-line bump to `transformers>=4.51.0`. `sentence-transformers==3.3.1` is compatible with this range. Please test in your environment before merging.

Low-to-medium priority.
